### PR TITLE
APW's changes and questions/suggestions

### DIFF
--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -239,19 +239,20 @@ commitment to---or even use of---physical models of stars or the Milky Way.
 \begin{figure}
 \centering
   \includegraphics[width=\textwidth]{toy.png}
-\caption{ {\bf Why does this work}: An example of generating posterior beliefs of true values from noisy data by using the noise-deconvolved distribution of data as a prior. The upper left panel visualizes the simplified toy distribution. The red lines are the $1\sigma$ contours of the distribution, and the red points are 1024 samples from the distribution. These same $1\sigma$ contours are drawn in the bottom left panel. In the upper right and lower left panel, the grey points are these same 1024 samples of the distribution but with some measurement uncertainty added to them. The error bars show the $1\sigma$ measurement uncertainties. The black points are 5 randomly chosen data to highlight the method. In the lower left panel, the blue lines represent the noise deconvolved, best estimate for the underlying distribution. The blue points represent the posterior belief of the true values of the noisy black points using the noise deconcolved distribution as the prior. The red points represent the actual true values. The lower right panel shows the posterior belief of the true value for all the points. They are colored by the measurement uncertainty, showing that data with larger measured variance are more influenced by the prior and lie towards the center of the noise deconvolved distribution, or prior. In contrast, more certain measurements tend to lie closer to their measured value. The blue points are better than the black for doing stuff.}
+\caption{ {\bf Why does this work}: An example of generating posterior beliefs of true values from noisy data by using the noise-deconvolved distribution of data as a prior. The upper-left panel visualizes the simplified toy distribution. The red lines are the $1\sigma$ contours of the distribution, and the red points are 1024 samples from the distribution. These same $1\sigma$ contours are drawn in the bottom left panel. In the upper-right and lower-left panel, the grey points are these same 1024 samples of the distribution but with some measurement uncertainty added to them. The error bars show the $1\sigma$ measurement uncertainties. The black points are 5 randomly chosen data to highlight the method. In the lower-left panel, the blue lines represent the noise deconvolved, best estimate for the underlying distribution. The blue points represent the posterior belief of the true values of the noisy black points using the noise deconcolved distribution as the prior. The red points represent the actual true values. The lower-right panel shows the posterior belief of the true value for all the points. They are colored by the measurement uncertainty, showing that data with larger measured variance are more influenced by the prior and lie towards the center of the noise deconvolved distribution, or prior. In contrast, more certain measurements tend to lie closer to their measured value. The blue points are better than the black for doing stuff.}
 \label{fig:toy}
 \end{figure}
 
-In this paper we use the noise deconvolved observed \cmd\ as a prior to infer more precise parallax pdfs from \gaia\ measurements.
-Understanding this method is challenging because we are using the data both for the prior and the likelihood in our inference.
-To ease understanding, here we will demonstrate this method with a simpler toy model.
-Instead of inferring more precise parallax pdfs using the 2D distribution of the \cmd\ as our prior, for this simpler model we will infer more precise pdfs of the value $Y$.
-We will do this simpler inference using a prior that is also a 2D distribution: a 1D Gaussian in the y-direction, with a running mean $\mu = mx + b$ and some thickness $t$.
-Here the thickness of the toy distribution mimics the true thickness of the \cmd\ due to age, mass and metallicity.
-The $1\sigma$ contours as well as (noise free) samples from the toy model distribution are shown in Figure \ref{fig:toy}, upper left panel.
-Similarly, noisy samples from this distribution are shown in the upper right panel.
-Using a representation of the true distribution (which we learn from the noisy data) as our prior, we can infer some posterior belief over $y_{\true,n}$, a true sample of the distribution, from $y_n$, a noisy sample of the distribution.
+In this paper we use the noise-deconvolved \cmd\ as a prior to infer more precise parallax probability distribution functions (pdfs) from \gaia\ measurements.
+Understanding the validity of this method can be challenging because we are using the data both for the prior and the likelihood in our inference.
+To ease understanding, here we demonstrate the generaly methodology using a
+simpler toy model with simulated data.
+Instead of inferring parallax pdfs using the 2D distribution of the \cmd\ as our prior, for this simpler model we will infer posterior pdfs of the value $Y$.
+We perform this simpler inference using a prior that is also a 2D distribution: a 1D Gaussian in the y-direction, with a running mean $\mu = m\,x + b$ and some thickness $t$.
+Here the thickness of the toy distribution mimics the true thickness or intrinsic scatter of the \cmd\ due to age, mass, and metallicity.
+The $1\sigma$ contours as well as (noise free) samples from the toy model distribution are shown in \figurename~\ref{fig:toy}, upper-left panel.
+Similarly, noisy samples from this distribution are shown in the upper-right panel.
+Using a representation of the true distribution (which we learn from the noisy data) as our prior, we can infer some posterior belief over $y_{\true,n}$, a true sample from the distribution, from $y_n$, a sample from the noise distribution.
 
 Setting up the problem in more detail, we have the true samples from the underlying distribution and the noisy samples
 \begin{eqnarray}
@@ -259,20 +260,20 @@ y_{\true, n} \, &=& \, m_{\true}\,x_n + b_{\true} + \Delta_n \\
 y_n \, &=& \, y_{\true,n} + \epsilon_n \quad,
 \label{eq:ytrue}
 \end{eqnarray}
-where $\Delta_n$ is drawn from the Gaussian function $\mathcal{N}(\Delta_n \given 0, t^2)$, and $\epsilon_n$ is drawn from the Gaussian function $\mathcal{N}(\epsilon_n \given 0, \sigma_n^2)$, so $\sigma_n$ is the measurement uncertainty.
-These represent true and noisy draws from a distribution that is a straight line with some thickness $t$, and are visualized in the upper panels of Figure \ref{fig:toy}
-The upper left shows 1024 realizations of the true values, and the upper right, as well as lower left, show 1024 realizations of the noisy values $y_n$ and their associated measurement uncertainties $\sigma_n$ as the grey points. Here we highlight 5 random points in black to highlight the method, but the same method is being applied to all the data.
+where $\Delta_n$ is drawn from the Gaussian function $\mathcal{N}(\Delta_n \given 0, t^2)$---which accounts for the intrinsic width---and $\epsilon_n$ is drawn from the Gaussian function $\mathcal{N}(\epsilon_n \given 0, \sigma_n^2)$---the noise distribution---so $\sigma_n$ is the measurement uncertainty.
+These represent true and noisy draws from a distribution that is a straight line with some thickness $t$, and are visualized in the upper panels of \figurename~\ref{fig:toy}.
+The upper-left shows 1024 realizations of the true values, and the upper-right, as well as lower-left, show 1024 realizations of the noisy values $y_n$ and their associated measurement uncertainties $\sigma_n$ as the grey points; we highlight 5 random points in black.
 
-To infer a pdf of the true y value for each measured y value we need a prior. For our prior we will use an estimate of the underlying true distribution that the noisy data $y_n$ are drawn from, which we build from the noisy y data themselves.
-We learn the noise-deconvolved function using marginalized maximum likelihood estimation (MML), which marginalizes over the true data values (we never need to know them) and maximizes the likelihood of the data. Here our likelihood for each individual datum is
+To infer a posterior pdf of the true $y$ value for each measured $y$ value we need a prior. We use an estimate of the underlying true distribution that the noisy data $y_n$ are drawn from, which we build from the noisy $y$ data themselves.
+We learn the noise-deconvolved function using marginalized, maximum-likelihood estimation (MMLE), which marginalizes over the true data values and maximizes the likelihood of the data. Here our likelihood for each individual datum is
 \begin{eqnarray}
 p(y_n \given m, b, t^2, \sigma_n^2) \ &=& \ \int \mathcal{N}(y_n \given y_{\true,n}, \sigma_n^2) \, \mathcal{N}(y_{\true,n} \given m\,x_n + b, t^2 ) \, \mathrm{d}y_{\true, n} \\
 &=&  \ \mathcal{N}(y_n \given m\,x_n + b, t^2 + \sigma_n^2) \quad,
 \label{eq:toyLike}
 \end{eqnarray}
-where we have marginalized over the true sample $y_{\true, n}$. The resulting likelihood is a Gaussian because the noise model is a Gaussian. The likelihood of the full data set is then the product of the individual likelihoods
+where we have marginalized over the true sample $y_{\true, n}$. The resulting likelihood is a Gaussian because the noise model and our assumptions about the intrinsic width are both Gaussian. The likelihood of the full data set $\{y_n\}$ is then the product of the individual likelihoods
 \begin{equation}
-\prod_n\, p(y_n \given m, b, t^2, \sigma_n^2) \quad .
+p(\{y_n\} \given m, b, t^2, \sigma_n^2) = \prod_n\, p(y_n \given m, b, t^2, \sigma_n^2) \quad .
 \label{eq:toyLikeFull}
 \end{equation}
 Maximizing this joint likelihood of all the data is the same as minimizing
@@ -282,33 +283,33 @@ Maximizing this joint likelihood of all the data is the same as minimizing
 \label{eq:chisq}
 \end{equation}
 
-This MML gives us the best fit parameters $\hat{m}$, $\hat{b}$, and $\hat{t}$. In Figure \ref{fig:toy}, lower left panel, the true functions $y_{\true} = m_{\true}\,x + b_{\true} \pm t_{\true}$ are shown as the red lines, and the best fit MML functions $\hat{y}_{\true} = \hat{m}\, x + \hat{b} \pm \hat{t}$ are shown as the blue lines. Now that we have an estimate of the true underlying distribution $\hat{y}_{\true}$, we use this as a prior to infer a posterior belief of the true values for each datum $p(y_{\true,n} \given y_n, \tilde{\sigma}_n^2)$.
+The MMLE gives us the best fit parameters $\hat{m}$, $\hat{b}$, and $\hat{t}$. In \figurename~\ref{fig:toy}, lower-left panel, the true functions $y_{\true} = m_{\true}\,x + b_{\true} \pm t_{\true}$ are shown as the red lines, and the best fit MMLE functions $\hat{y}_{\true} = \hat{m}\, x + \hat{b} \pm \hat{t}$ are shown as the blue lines. Now that we have an estimate of the true underlying distribution $\hat{y}_{\true}$, we use this as a prior to infer a posterior belief of the true values for each datum $p(y_{\true,n} \given y_n, \tilde{\sigma}_n^2)$.
 
 Here is a good point to step back and acknowledge that our method is a
-bit strange. We are using the set of data to determine the
-noise-deconvolved distribution, which is an estimate of the true
-distribution, and then using that noise-deconvolved distribution to
-make inferences on the data. We are technically using the data
+bit strange. We are using the data to determine the
+noise-deconvolved distribution (an estimate of the true
+distribution), and then using that noise-deconvolved distribution to
+make inferences about the data. We are technically using the data
 twice! To be fully, technically correct, we should \emph{either} learn the true
 distribution while leaving one datum out, the one datum we want to
-infer the true y value for, or else go to full hierarchical Bayesian inference,
+infer the true y value for, or else perform a full hierarchical Bayesian inference,
 in which we treat the \cmd\ parameters probabilistically along with everything else.
-With large data sets, the MML or Empirical Bayes approximation is safe,
+With large data sets, the MMLE or Empirical Bayes approximation is safe,
 in some sense because no individual data point makes a large difference to
 the inference.
 
-Returning the inference:
-We use Bayes theorem to turn the likelihood of the noisy data into a posterior believe over the true y value.
+Returning to the inference:
+We use Bayes' theorem to turn the likelihood of the noisy data into a posterior belief over the true $y$ value:
 \begin{eqnarray}
 p(y_{\true,n} \given y_n, \tilde{\sigma}_n) &=& p(y_n \given y_{\true,n}, \sigma_n)\,p(y_{\true,n}) \\
 \mathrm{where}\;p(y_n \given y_{\true,n}, \sigma_n) &=& \mathcal{N}(y_n \given y_{\true,n}, \sigma_n) \\
 \mathrm{and}\;p(y_{\true,n}) &=& \mathcal{N}(y_{\true,n} \given \hat{m}\, x_n + \hat{b}, \hat{t})
 \label{eq:toyBayes}
 \end{eqnarray}
-Since everything is Gaussian, this can be done analytically by multiplying Gaussians together. In Figure \ref{fig:toy} lower left panel, the blue points represent the posterior belief of the true value $p(y_{\true,n} \given y_n, \tilde{\sigma}_n)$ for the highlighted black points. The red points are the associated true y values.
-In Figure \ref{fig:toy}, lower right panel, the blue points show the expectation value and $1\sigma$ uncertainty of the posterior belief for all 1024 $y_n$.
+In \figurename~\ref{fig:toy} lower-left panel, the blue points represent the posterior beliefs of the true values $y_{\true,n}$ for the 5 highlighted black points from the upper-right panel. The red points are the associated true $y$ values.
+In the lower-right panel of \figurename~\ref{fig:toy}, the blue points show the expectation value and $1\sigma$ uncertainty of the posterior belief for all 1024 $y_n$.
 When the true values are inferred in this way, the associated variance $\tilde{\sigma}_n^2$ is the convolution of the true distribution variance, $t^2$, and the measurement variance, $\sigma_n^2$.
-The points are colored by their measurement variance $\sigma_n^2$, which shows that noisier measurements are more influenced by the prior and get pulled closer to the center of the MML distribution, our prior. In contrast, more certain measurements remain closer to their measured values, $y_n$. We now have better estimates of each true y value by inferring each true y value from the measured y value and using an estimate of the true distribution the measured y value was drawn from as the prior.
+The points are colored by their measurement variance $\sigma_n^2$, which shows that noisier measurements are more influenced by the prior and get pulled closer to the center of the MMLE distribution, our prior. In contrast, more certain measurements remain closer to their measured values, $y_n$. We now have better estimates of each true y value by inferring each true y value from the measured y value and using an estimate of the true distribution the measured y value was drawn from as the prior.
 
 In detail, the posterior points shown in the lower-right panel of
 Figure~\ref{fig:toy} look more concentrated (vertically) than the true
@@ -479,7 +480,7 @@ with $f(\varpi_{true})$ being a window function to insure $\varpi_{\true}$ is po
 \label{fig:data}
 \end{figure}
 
-We use stars crossmatched in \tgas\ and \tmass\, that also lie within the observing footprint of \panstarrs\ to access the Greene 3D dust model. We require the photometry have real values, and nonzero, real errors, and remove a small selection of \tmass\ stars that have zero color and zero J band magnitude. The full data set is visualized in the \cmd\ in Figure \ref{fig:data}. The left panel shows the point estimates of the color and absolute magnitude, using the point estimate of the parallax from \gaia, and the $1\sigma$ and $2\sigma$ contours of the distribution. The right panel shows a subset of the data with it's associated error bars. The uncertainties in the colors are fairly well behaved, but the large uncertainties in the absolute magnitude are due to the large uncertainties in the parallax measurements.
+We use stars crossmatched in \tgas\ and \tmass\, that also lie within the observing footprint of \panstarrs\ to access the Greene 3D dust model. We require the photometry have real values, and nonzero, real errors, and remove a small selection of \tmass\ stars that have zero color and zero J band magnitude. The full data set is visualized in the \cmd\ in \figurename~\ref{fig:data}. The left panel shows the point estimates of the color and absolute magnitude, using the point estimate of the parallax from \gaia, and the $1\sigma$ and $2\sigma$ contours of the distribution. The right panel shows a subset of the data with it's associated error bars. The uncertainties in the colors are fairly well behaved, but the large uncertainties in the absolute magnitude are due to the large uncertainties in the parallax measurements.
 
 \subsection{Dust}
 
@@ -521,7 +522,7 @@ probabilistic dust model. We apply each light dust correction to our
 cite{schlafly11}. We then regenerate our prior using the lightly dust
 corrected photometry. The dust values we obtain in our final
 iteration, and which we apply to our photometry, are visualized in
-galactic coordinates in Figure \ref{fig:dust}. After applying a dust
+galactic coordinates in \figurename~\ref{fig:dust}. After applying a dust
 correction, we do not update the uncertainties, but keep them the same
 as before the dust correction, which is wrong and under representing
 our uncertainties but this leads, again, to a lighter
@@ -544,8 +545,8 @@ corresponding dust to become more consistent with the \cmd.
 Should I quote some statistics about the dust corrections? mostly small? maybe difference before/after applying prior to distance?
 
 \subsection{XD-generated Prior}
-Using \xd\ and the MML method described in the methods section, we generate the prior. This is shown in Figure \ref{fig:prior}.
-This is the \gaia\ + \tmass\ data set deconvolved with it's noise, so compared with the raw data in Figure \ref{fig:data}, this is a tighter distribution. The left panel shows 1.3M samples from the prior distribution, and the right panel shows the underlying gaussian mixture model these samples are drawn from. The main sequence and red giant branch are much tighter, as well as the red clump. We'll come back to more features in the data below, especially those seen in the posterior distribution.
+Using \xd\ and the MMLE method described in the methods section, we generate the prior. This is shown in \figurename~\ref{fig:prior}.
+This is the \gaia\ + \tmass\ data set deconvolved with it's noise, so compared with the raw data in \figurename~\ref{fig:data}, this is a tighter distribution. The left panel shows 1.3M samples from the prior distribution, and the right panel shows the underlying gaussian mixture model these samples are drawn from. The main sequence and red giant branch are much tighter, as well as the red clump. We'll come back to more features in the data below, especially those seen in the posterior distribution.
 \begin{figure}
 \centering
   \includegraphics[width=\textwidth]{prior_ngauss128.png}
@@ -628,7 +629,7 @@ So it is a great test case for comparing parallax inferences with or without a p
 We made a window of 1 square degree on the sky with the cluster M67 lying in the middle.
 The cluster is visibly obvious as a clustering of stars in a visualization of the \gaia\ data on the 2D sky.
 With our converged dust values, and its associated prior, we calculate the posterior over $\varpi_{\true}$ for each star within this window on the sky around M67.
-Figure \ref{fig:m67} shows the comparison of the likelihoods and posteriors.
+\figurename~\ref{fig:m67} shows the comparison of the likelihoods and posteriors.
 The vertical lines bracket the previously measured parallaxes of, or distances to, the cluster.
 The likelihoods of the observed parallaxes, shown in the top row, are broad and the cluster is not obvious at all.
 The posterior pdf, shown in the bottom row, are more sharply peaked at the previously determined distance to the cluster, the vertical lines, for far more stars than the likelihoods.
@@ -700,7 +701,7 @@ One option is the exponentially declining spatial density (EDSD) of stars \citep
 It is parameterized by a scale length, and has the nice property that it is smooth out to very large distances so the posteriors are also very smooth.
 It is a fairly weak prior.
 It sets a smooth scale distance beyond which the posterior struggles to maintain much probability, and also converts a negative parallax likelihood into a posterior of very small parallax.
-A comparison of the posteriors using the two different priors, our \cmd\ prior and the EDSD, is shown in Figure \ref{fig:comparePrior}.
+A comparison of the posteriors using the two different priors, our \cmd\ prior and the EDSD, is shown in \figurename~\ref{fig:comparePrior}.
 Here the parallax posterior pdf expectation value and square root of the variance is converted into an absolute magnitude and visualized as the \cmd.
 The left panel visualizes results using our \cmd\ prior, and the right panel visualizes results using the EDSD prior.
 The variance for the \cmd\ prior is significantly smaller than the variance for the EDSD prior.
@@ -709,7 +710,7 @@ It has the largest effect on the most noisy and negative parallaxes, and has the
 
 \subsection{What's That Feature?}
 The denoised expectation values of the parallax projected into the \cmd\ show interest features.
-We visualize this \cmd\ again in Figure \ref{fig:wtf} pointing out some interesting features.
+We visualize this \cmd\ again in \figurename~\ref{fig:wtf} pointing out some interesting features.
 \begin{figure}
 \centering
   \includegraphics[width=\textwidth]{whatsThatFeature.pdf}

--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -379,7 +379,6 @@ method that flows from them---in the discussion section below.
 \end{description}
 
 \subsection{Setting up the Inference}
- \emph{Think about presentation, prioritizing/highlighting prior but logically building it from an full inference perspective and needing a prior, then dive into prior stuff. It's confusing right now jumping between inference and prior building !!}
 
 Under these assumptions, we would like to infer the true parallax, $\varpi_{\true}$, for each star given its measured parallax, $\varpi$, and associated uncertainty, $\sigma_{\varpi}$, from \tgas.
 A first application of Bayes theorem leads to
@@ -397,16 +396,17 @@ The tight correlation of the \cmd\ benefits our inference because the luminosity
 We include this in the inference by using the \cmd\ as part of our prior for $\varpi_{\true}$.
 Specifically, we use the \cmd\ generated from the data themselves, as detailed in the next section.
 
-Equation~\ref{eq:bayes} is too simplistic to describe this procedure.
-Because our prior is the \cmd, our inference will include not only the parallax from \gaia, but also the photometry of the stars. Specifically, we use the $J$ and $K$ band photometry from \tmass, as well as the parallax from \gaia. Our true, latent values are the $(J-K)^{true}_n$ color and the $J$ band absolute magnitude $M^{true}_{J,n}$ for each star, which we encapsulate in the true vector $\mathbf{Y}$. The observed data is the dust corrected color $(J-K)^c_n$, the \gaia\ parallax $\varpi_n$ in units of $[mas]$, and the dust corrected $J$ band magnitude $J^c_n$, which we encapsulate in the data vector $\mathbf{y}$.
+Equation~\ref{eq:bayes} does not fully specify this procedure.
+Because our prior comes from the \cmd, our inference will include not only the parallax from \gaia, but also the photometry of the stars. Specifically, we use the $J$ and $K$ band photometry from \tmass, as well as the parallax from \gaia. Our true, latent values are the $(J-K)^{true}_n$ color and the $J$ band absolute magnitude $M^{true}_{J,n}$ for each star, which we encapsulate in the true vector $\mathbf{Y}$. The observed data is the dust corrected color $(J-K)^c_n$, the \gaia\ parallax $\varpi_n$ in units of $[mas]$, and the dust corrected $J$ band magnitude $J^c_n$, which we encapsulate in the data vector $\mathbf{y}$.
 
 We now describe a singularity of our method, which allows us to conservatively deconvolve the data into a \cmd\ prior without requiring a full hierarchical inference framework (which was explored in \citealt{leistedtHogg2017}).
 Instead of transforming the parallax and apparent magnitude into an absolute magnitude, the data vector $\mathbf{y}$ contains a transformation of the dust corrected absolute magnitude
 \begin{equation}
-y_0 = \varpi\,10^{0.2J^c_n} = 10^{0.2\,M^c_{J,n} + 2}
+y_0 = \varpi\,10^{\frac{1}{5}\,J^c_n} = 10^{\frac{1}{5}\,M^c_{J,n} + 2}
 \label{eq:transform}
 \end{equation}
-The transformation of the dust corrected absolute magnitude is required to to keep the uncertainties Gaussian, which, under some assumptions along with this transformation, we maintain. Gaussian uncertainties are required to generate our prior using \xd, but more about this and our dust corrections below.
+where, for this expression, it is important to remember that $\varpi$ is assumed to be in units of $[mas]$.
+The transformation of the dust corrected absolute magnitude is required to to keep the uncertainties Gaussian, which, under some assumptions along with this transformation, we maintain (Gaussian uncertainties are required to use \xd, see below).
 Our prior assumptions $I$ are the uncertainties in each of these measurements, as well as the 3D dust map. So our full terminology is
 \begin{equation}
 \begin{aligned}
@@ -420,7 +420,7 @@ Our prior assumptions $I$ are the uncertainties in each of these measurements, a
 \end{equation}
 where $E(B-V)_n$ is the output of the dust model of \cite{green15}, and $Q_{\lambda}$ is the correction factor for a photometric band assuming some reddening law.
 
-We assume that the parallax likelihood is Gaussian, as well as the $(J-K)^c_n$ color likelihood. So our full likelihood of the $n$th star is
+We assume that the parallax likelihood is Gaussian, as well as the $(J-K)^c_n$ color likelihood. So our full likelihood for the $n$th star is
 \begin{equation}
 p(\mathbf{y}_n \given \mathbf{Y}_n, I_n) = \mathcal{N}(\mathbf{y}_n \given \mathbf{Y}_n, V_n)
 \end{equation}
@@ -428,32 +428,31 @@ with \\
 \[
 V_n = \begin{bmatrix}
 \sigma_{J,n}^2 + \sigma_{K,n}^2 & 0 \\
-0 & (\sigma_{\varpi}\,10^{0.2\,J_n^C})^2
+0 & \left(\sigma_{\varpi}\,10^{0.2\,J_n^C}\right)^2
 \end{bmatrix}
 \]
-where $\mathcal{N}$ is a 2D Gaussian function with mean $\mathbf{Y}$ and variance $V_n$.
-Here we have assumed that the parallax uncertainty is significantly larger than the $J$ band uncertainty, and therefore the dominant uncertainty in the transformed absolute magnitude. So we take $J_n^C$ as a point estimate and only propagate the parallax uncertainty.
+where $\mathcal{N}(\boldsymbol{\mu}, \mathbf{\Sigma})$ represents a normal distribution with mean vector $\boldsymbol{\mu}$ and covariance matrix $\mathbf{\Sigma}$.
+Here we have assumed that the parallax uncertainty is significantly larger than the $J$-band magnitude uncertainty and is therefore the dominant uncertainty in the transformed absolute magnitude. We take $J_n^C$ as a point estimate and only propagate the parallax uncertainty.
 
-We can now write the multidimensional analogous to Equation \ref{eq:bayes},
+We can now write the multidimensional posterior expression analogous to Equation~\ref{eq:bayes},
 \begin{equation}
-p(\mathbf{Y}_n \given \mathbf{y}_n, I_n) = p(\mathbf{y}_n \given \mathbf{Y}_n, I_n) \, p(\mathbf{Y}_n) \label{eq:posterior}
+p(\mathbf{Y}_n \given \mathbf{y}_n, I_n) \propto p(\mathbf{y}_n \given \mathbf{Y}_n, I_n) \, p(\mathbf{Y}_n) \label{eq:posterior}
 \end{equation}
 where $p(\mathbf{y}_n \given \mathbf{Y}_n, I_n)$ is the likelihood of the data vector, and $p(\mathbf{Y}_n)$ is our prior.
-Before we describe how this can be turned into a posterior belief on the true parallax, we turn our attention to the prior, which will be generated from the data themselves. We will use XD, which will take advantage of the Gaussian likelihood.
+Before we describe how this can be turned into a posterior belief on the true parallax, we turn our attention to the prior, which will be generated from the data themselves. For this, we use XD, which takes advantage of the Gaussian likelihood.
 
 \subsection{Generating the Prior}
 
-To generate our prior $p(\mathbf{Y}_n)$, we fit our data in the slightly transformed \cmd\ space using \xd, which deconvolves the data $\{ \mathbf{Y}_n \}$ with its uncertainties $\{ V_n\}$, which are Gaussian, heterogeneous measurement uncertainties. It generates an estimate of the underlying distribution from which the uncertain data were drawn from, modeled as a mixture of $K$ Gaussians:
+To generate the empirical prior $p(\mathbf{Y}_n)$, we fit our data in the transformed \cmd\ space (see previous sub-section) using \xd, which deconvolves the data $\{ \mathbf{Y}_n \}$ with heterogeneous, Gaussian noise variances $\{ V_n\}$. \xd\ generates an estimate of the underlying distribution from which the uncertain data were drawn, modeled as a mixture of $K$ Gaussians:
 \begin{equation}
-	p\bigl(\ \mathbf{Y} \given  \left\{\mathrm{amp}_k, \mathbf{\mu}_k, V_k\right\}_{k=1}^K \bigr) = \sum_{k=1}^K \mathrm{amp}_k \ \mathcal{N}(\mathbf{Y} \given \mathbf{\mu}_k, V_k )
+	p\bigl(\ \mathbf{Y} \given  \left\{A_k, \mathbf{\mu}_k, V_k\right\}_{k=1}^K \bigr) = \sum_{k=1}^K A_k \ \mathcal{N}(\mathbf{Y} \given \mathbf{\mu}_k, V_k )
 \end{equation}
-where $\mathbf{\mu}_k$ and $V_k$ are a two dimensional vector and matrix, respectively, which correspond to the location and covariance of the $k$th component (a Gaussian in our transformed \cmd\ space). The relative amplitudes between the components are described by the scalars $\{ \mathrm{amp}_k \}$.
+where $\mathbf{\mu}_k$ and $V_k$ are a two dimensional vector and matrix, respectively, which correspond to the location and covariance of the $k$th component (a Gaussian in our transformed \cmd\ space). The relative amplitudes between the components are described by the scalars $\{ A_k \}$.
 
-Given the data $\{ \mathbf{Y}_n, V_n\}$, \xd\ maximizes the marginalized likelihood of the data, marginalizing over the true data. In equations, it finds the coefficients
+Given the data $\{ \mathbf{Y}_n, V_n\}$, \xd\ maximizes the marginalized likelihood of the data, marginalizing over the true data. Assuming $\alpha = \left\{A_k, \mathbf{\mu}_k, V_k\right\}_{k=1}^K$, it finds the coefficients
 \begin{eqnarray}
-\alpha &=& \left\{\mathrm{amp}_k, \mathbf{\mu}_k, V_k\right\}_{k=1}^K \nonumber\\
-       &=& \argmax_{\alpha} \, \Pi_n \, p(\mathbf{y}_n \given \alpha) \nonumber\\
-       &=& \argmax_{\alpha} \, \Pi_n \, \int p(\mathbf{y}_n \given \mathbf{Y}_n) \, p(\mathbf{Y}_n \given \alpha)\mathrm{d\mathbf{Y}_n}
+\hat{\alpha} &=& \argmax_{\alpha} \, \prod_n \, p(\mathbf{y}_n \given \alpha) \nonumber\\
+             &=& \argmax_{\alpha} \, \prod_n \, \int p(\mathbf{y}_n \given \mathbf{Y}_n) \, p(\mathbf{Y}_n \given \alpha)\mathrm{d\mathbf{Y}_n}
 \label{eq:xdmml}
 \end{eqnarray}
 which is made analytically tractable with the Gaussian likelihood and mixture-of-Gaussians prior \citep{bovy11}.

--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -94,11 +94,12 @@ million \tgas\ stars, are available in companion electronic tables.
 
 \section{Introduction}
 
-The \gaia\ Mission (\citealt{gaia16}) will deliver more than a billion stellar parallax measurements.
+The \gaia\ Mission (\citealt{gaia16}) will soon deliver more than a billion
+stellar parallax measurements.
 Only a small fraction (but large number) of these
 measurements will be both precise and purely astrometric.
-\gaia\ will use astrometric parallax to determine the distances of the more precise
-stars, and then calibrate spectrophotometric models.
+\gaia\ will use astrometric parallaxes to determine the distances of the more
+precise stars, and then calibrate spectrophotometric models.
 These spectrophotometric models, in turn, along with \gaia's on-board
 low-resolution $B_p\,R_p$ spectrophotometry, are used to provide
 parallax estimates to less precise stars.
@@ -154,11 +155,10 @@ When using physical models, it is impossible to deliver photometric parallax est
 
 However, the use of physical models for distance estimation is not necessary.
 It is possible to build a stellar photometric model from the data themselves,
-because there are stars at all luminosities with useful parallax information,.
+because there are stars at all luminosities with useful parallax information.
 One challenge is that different stars are observed at different levels of parallax precision,
 so it requires relatively sophisticated technology to build this data-driven model
-using all the data available, fairly and responsibly.
-Luckily, we have this technology!
+using all of the data available, fairly and responsibly.
 
 Here we build and use just such a data-driven model to infer more precise parallaxes for each star.
 In particular, we use all of the \gaia\ \tgas\ data (\citealt{tgas};
@@ -194,11 +194,10 @@ Technically, since \xd\ produces a maximum-marginalized-likelihood estimator
 of the deconvolved distribution,
 its use as a prior is technically using the data twice and is therefore only approximately valid.
 However, since the data set is large, the \xd\ approximation is not bad; it is
-sometimes known as the ``empirical Bayes'' method, and is well studied\footnote{For a start, try \url{https://en.wikipedia.org/wiki/Empirical_Bayes_method}.}.
+sometimes known as the ``empirical Bayes'' method, and is well studied.\footnote{For a primer on ``empirical Bayes'', see \url{https://en.wikipedia.org/wiki/Empirical_Bayes_method}.}
 
-It wouldn't be using the data twice---that is, it would be valid from a
-probabilistic perspective---if we performed a full hierarchical Bayesian
-inference.
+A probabilistically valid approach that wouldn't re-use the data is to perform
+a full hierarchical Bayesian inference.
 Exploration of that possibility, and its computational tractability,
 is among our long-term goals and motivations.
 Along those lines, this paper can be seen as a companion to a related
@@ -232,7 +231,7 @@ We have to use photometry that is ground-based, rather than the full-precision,
 space-based photometry that the \gaia\ Mission will deliver.
 However, as we show below, we get very good results in terms of parallax precision.
 It is promising that we will be able to obtain even better results
-in later \gaia\ data releases, and eventually put distances on $>10^9$
+using later \gaia\ data releases, and eventually infer distances for $>10^9$
 \gaia\ stars using photometric parallax methodologies but without any
 commitment to---or even use of---physical models of stars or the Milky Way.
 

--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -45,8 +45,8 @@
 \author[0000-0002-3962-9274]{Boris Leistedt}
 \affil{Center for Cosmology and Particle Physics, Department of Physics, New York University, 726 Broadway, room 1005, New York, NY 10003, USA}
 
-\author[0000-0003-0872-7098]{Adrian Price-Whelan}
-\affil{Princeton University Observatory, Princeton University, 4 Ivy Lane, Princeton, NJ 08544, USA}
+\author[0000-0003-0872-7098]{Adrian M. Price-Whelan}
+\affil{Department of Astrophysical Sciences, Princeton University, 4 Ivy Lane, Princeton, NJ 08544, USA}
 
 %\author{Jo Bovy}
 %\affil{Center for Computational Astrophysics, Flatiron Institute, 162 Fifth Ave, New York, NY 10010, USA}

--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -664,8 +664,8 @@ Our prior is not only making parallaxes more precise but also (possibly) increas
 \section{Discussion}
 
 We have shown that it is possible to obtain photometric parallaxes for
-distant stars in the \gaia\ \tgas\ data without any use of physical stellar
-models, nor models of the Milky Way.
+distant stars in the \gaia\ \tgas\ catalog without any use of physical stellar
+models, nor stellar density models of the Milky Way.
 We used the geometric parallaxes to calibrate a photometric
 model that is purely statistical, which is a model of the data rather than
 a model of stars \foreign{per se}.
@@ -699,10 +699,10 @@ This deconvolution, using a reasonable noise model and an
 assumption of stationarity, shrinks the parallax uncertainties, most dramatically for the stars measured at lower signal-to-noise.
 Because the method we use, \xd, which is
 an Empirical Bayesian maximum-marginalized-likelihood estimator, accounts for
-heteroskedastic noise, we were able to build our photometric parallax
+heteroskedastic noise, we are able to build our photometric parallax
 model---which is a model of the \cmd---using
 all the data, not just the data with the highest signal-to-noise.
-So, the model for the \cmd\ we built is representative for
+So, the generated model for the \cmd\ is representative for
 our subset of the \tgas\ Catalog.
 Because our model is representitive of our full subset catalog, we expect any (sensible) parallax estimates
 we generate from our parallax posterior pdfs to be only weakly biased.
@@ -711,16 +711,16 @@ we generate from our parallax posterior pdfs to be only weakly biased.
 \begin{figure}
 \centering
   \includegraphics[width=\textwidth]{comparePrior.png}
-\caption{Comparison with common prior: A visualization of the posterior pdf for a subsection of TGAS stars, shown as the expectation value and the sqrt of the variance as the uncertainty. On the left is the posterior pdf using our \cmd\ prior, and on the right is the posterior pdf when using the exponentially declining spatial density, a common prior used when inferring parallaxes. The scale of the exponentially declining spatial density prior is 1.35 kpc, the optimal value found in \cite{astraatmadja16a}. Using the \cmd\ as a prior generates a posterior pdf that has smaller variance.}
+\caption{Comparison with a common spatial prior: A visualization of the posterior pdf for a subsection of \tgas\ stars, shown as the expectation value and the sqrt of the variance as the uncertainty. Left panel shows the posterior pdf using our \cmd\ prior, right panel shows the posterior pdfs when using the exponentially declining spatial density, a common space-density prior used when inferring distances. The scale of the exponentially declining spatial density prior is $1.35~{\rm kpc}$, the optimal value found in \cite{astraatmadja16a}. Using the \cmd\ as a prior generates a posterior pdf that has smaller variance.}
 \label{fig:comparePrior}
 \end{figure}
 
 There are other options for prior information to include when inferring distances to stars.
 One option is the exponentially declining spatial density (EDSD) of stars \citep{astraatmadja16a}.
-It is parameterized by a scale length, and has the nice property that it is smooth out to very large distances so the posteriors are also very smooth.
+It is parameterized by a scale length, and has the nice property that it is smooth out to very large distances so that the posteriors are also very smooth.
 It is a fairly weak prior.
 It sets a smooth scale distance beyond which the posterior struggles to maintain much probability, and also converts a negative parallax likelihood into a posterior of very small parallax.
-A comparison of the posteriors using the two different priors, our \cmd\ prior and the EDSD, is shown in \figurename~\ref{fig:comparePrior}.
+\figurename~\ref{fig:comparePrior} shows a comparison of the EDSD prior with our \cmd\ prior.
 Here the parallax posterior pdf expectation value and square root of the variance is converted into an absolute magnitude and visualized as the \cmd.
 The left panel visualizes results using our \cmd\ prior, and the right panel visualizes results using the EDSD prior.
 The variance for the \cmd\ prior is significantly smaller than the variance for the EDSD prior.
@@ -728,8 +728,7 @@ In general, it is a fairly broad prior so the median \gaia\ star has a posterior
 It has the largest effect on the most noisy and negative parallaxes, and has the nice property of bringing these noisy or negative measurements to reasonable parallaxes.
 
 \subsection{What's That Feature?}
-The denoised expectation values of the parallax projected into the \cmd\ show interest features.
-We visualize this \cmd\ again in \figurename~\ref{fig:wtf} pointing out some interesting features.
+The denoised expectation values of the parallax projected into the \cmd\ show many interesting and familiar features; we visualize this \cmd\ again in \figurename~\ref{fig:wtf} and highlight some of these features.
 \begin{figure}
 \centering
   \includegraphics[width=\textwidth]{whatsThatFeature.pdf}
@@ -739,13 +738,13 @@ We visualize this \cmd\ again in \figurename~\ref{fig:wtf} pointing out some int
 
 The lower main sequence is very narrow while the upper main sequence
 is much wider. This may be an age variation on the main sequence mixed
-with a malmquist bias of seeing a much larger volume of upper main
+with a Malmquist bias of seeing a much larger volume of upper main
 sequence stars. There is a plausible binary sequence of stars with
 about twice the brightness as the main sequence. The helium burning
 red clump is prominent for the volume DR1 probed, and the red giant
 branch is fairly straight and narrow. The main sequence turn off is
 noticeable and also surprisingly narrow, possibly a reflection of the
-star formation history of the local volume also mixed with a malmquist
+star formation history of the local volume also mixed with a Malmquist
 bias.
 
 \subsection{Critical discussion of assumptions}
@@ -763,14 +762,14 @@ detail, under the same set of assumption labels:
   This isn't precisely true because nearby stars in \tgas\ are
   mostly main sequence stars, while we can see luminous giants to much larger
   distances. So the red giant branch is a population of
-  relatively lower signal to noise objects compared with the main
+  relatively lower signal-to-noise objects compared with the main
   sequence. This does not violate the stationarity assumption in
-  detail, because the low and high signal to noise objects have to be
+  detail, because the low and high signal-to-noise objects have to be
   drawn from the same distribution within some feature or patch of the
   \cmd\ space.
 \item[selection] The biggest limitation of our method for generating
-  the \cmd\ from the data is that we made no use of any kind of
-  \tgas\ selection function or completeness estimate or
+  the \cmd\ from the data is that we have not used a
+  \tgas\ selection function, completeness estimate, or
   inverse-selection-volume corrections.  This model is a model of the
   \tgas\ Catalog (or really the \tgas--\tmass\ intersection), not of
   the stars in the Milky Way, nor any volume-limited subsample of the
@@ -827,7 +826,7 @@ detail, under the same set of assumption labels:
 \item[mixture of Gaussians] The \cmd\ model is a mixture of Gaussians,
   and furthermore fixed at $K=128$ components. This setting was chosen
   after some experimentation as being able to capture features but still
-  be easily optimized. We performed some experiments with
+  be easily optimized. We performed some experiments
   that suggest that larger $K$ would lead to better models, even in the
   conservative sense of cross-validation score. Choosing an optimized or
   optimal number for this mixture is a natural extension of this work.

--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -479,13 +479,25 @@ with $f(\varpi_{true})$ being a window function to insure $\varpi_{\true}$ is po
 \label{fig:data}
 \end{figure}
 
-We use stars crossmatched in \tgas\ and \tmass\, that also lie within the observing footprint of \panstarrs\ to access the Greene 3D dust model. We require the photometry have real values, and nonzero, real errors, and remove a small selection of \tmass\ stars that have zero color and zero J band magnitude. The full data set is visualized in the \cmd\ in \figurename~\ref{fig:data}. The left panel shows the point estimates of the color and absolute magnitude, using the point estimate of the parallax from \gaia, and the $1\sigma$ and $2\sigma$ contours of the distribution. The right panel shows a subset of the data with it's associated error bars. The uncertainties in the colors are fairly well behaved, but the large uncertainties in the absolute magnitude are due to the large uncertainties in the parallax measurements.
+We use stars crossmatched in \tgas\ and \tmass\, that also lie within the
+observing footprint of \panstarrs\ to access the \cite{green15} 3D dust model.
+We require that the photometry have real values, and nonzero, real errors, and
+remove a small selection of \tmass\ stars that have zero color and zero $J$-band
+magnitude.
+The full data set is visualized in the \cmd\ in \figurename~\ref{fig:data}.
+The left panel shows the point estimates of the color and absolute magnitude,
+using the point estimate of the parallax from \gaia, and the $1\sigma$ and
+$2\sigma$ contours of the distribution.
+The right panel shows a subset of the data with it's associated error bars.
+The uncertainties in the colors are fairly well behaved, but the large
+uncertainties in some absolute magnitudes are due to the large uncertainties in
+the parallax measurements.
 
 \subsection{Dust}
 
-We need to correct the photometry used in our method, both for the
-generation of the prior and the likelihood, for dust. With the
-emergence of 3D dust maps, it is now possible to estimate dust
+For the generation of the prior and the evaluation of the likelihood, we need to
+correct the \tmass\ photometry for dust extinction.
+With the emergence of 3D dust maps, it is now possible to estimate dust
 corrections to stars within the Milky Way. The challenge is getting a
 proper estimate of the distance to the star before inferring
 $\varpi_{\true}$, since we need a dust correction prior to doing our
@@ -496,7 +508,7 @@ therefore have severe dust corrections. This is most obvious in the
 giant stars, which tend to have the lowest signal to noise, and can
 therefore have dust corrections $> 2$ magnitudes. Although the dust
 model is probabilistic, as well as our distance inference, to move
-forward, we break from a fully Bayesian framework, in which we might
+forward, we break from a fully Bayesian framework in which we might
 infer the distance and the dust simultaneously (more about this in the
 discussion). Instead, we correct for dust using a point estimate from
 the 3D dust map \citep{green15} sampled at a distance estimated from
@@ -506,26 +518,30 @@ $\varpi_{\true}$. In more detail, to apply a dust correction to the
 attenuated photometry. Using this raw prior, we infer more precise
 parallaxes to all the stars in our sample. We then use this more
 precise parallax posterior to get a measurement of dust in the 3D dust
-map for each star. And repeat. This approach minimizes severe
+map for each star. We then iterate this procedure. This approach minimizes severe
 distances, and their associated severe dust corrections, which would
-occur if using the likelihoods alone. In detail, we take the $5\%$
-quantile of each distance posterior, so the closest bit of the
-posterior, and sample the 3D dust map at that distance. We take the
-$5\%$ quantile, as apposed to the median, for example, to do a light
-dust correction, because over correcting for dust can shoot the
-likelihood into an unphysical, different space of the \cmd\ and bias
-the parallax inference. For each distance, we sample the median of the
-probabilistic dust model. We apply each light dust correction to our
-\tmass\ photometry given by Equation \ref{eq:data} where $Q_{\lambda}$
-= [0.709, 0.302] for bands [J, K] respectively, taken from Table 6 of
-cite{schlafly11}. We then regenerate our prior using the lightly dust
-corrected photometry. The dust values we obtain in our final
+occur if using the likelihoods alone.
+
+In detail, we take the $5\%$
+quantile of each distance posterior (the closest part of the
+distance posterior) and query the 3D dust map at that distance.
+We take the $5\%$ quantile---as apposed to the median---to do a minimal dust
+correction because over-correcting for dust can push the peak of the likelihood
+function into an unphysical, different space of the \cmd\ and thus bias the
+parallax inference.
+For each distance, we sample the median of the
+probabilistic dust model. We apply each dust correction to our
+\tmass\ photometry using Equation~\ref{eq:data}, where $Q_{\lambda}
+= [0.709, 0.302]$ for bands $[J, K]$ respectively (see Table 6 in
+\citealt{schlafly11}).
+We then regenerate our prior using the dust-corrected photometry.
+The dust values we obtain in our final
 iteration, and which we apply to our photometry, are visualized in
-galactic coordinates in \figurename~\ref{fig:dust}. After applying a dust
-correction, we do not update the uncertainties, but keep them the same
-as before the dust correction, which is wrong and under representing
-our uncertainties but this leads, again, to a lighter
-deconvolution. In other words, the features of our inferred
+galactic coordinates in \figurename~\ref{fig:dust}.
+After applying the dust correction, we do not update the uncertainties, which is
+technically wrong and under-represents the true uncertainties; as mentioned
+previously, this leads to a less severe deconvolution.
+In other words, the features of our inferred
   \cmd\ are conservatively broad (broader than if we over-estimated
   the errors which would have lead to excessive deconvolution and
   unrealistically narrow features). We could add the covariance of
@@ -537,15 +553,19 @@ corresponding dust to become more consistent with the \cmd.
 \begin{figure}
 \centering
   \includegraphics[width=\textwidth]{dust.png}
-\caption{The converged dust values at the 5\% distance projected on the l,b galactic coordinates. This shows both the footprint of our analysis as well as the dust values we used. Each point represents a single star in our cross matched catalog. The large missing areas are due to the lack of dust values from \panstarrs\ since it only looked above -30 degrees in dec }
+\caption{The converged dust values at the 5\% distance quantile in Galactic coordinates. This shows both the footprint of our analysis as well as the adopted extinction values. Each point represents a single star in our cross matched catalog. The large missing areas are due to the \panstarrs\ footprint ($>-30~{\rm deg}$ in declination)}
 \label{fig:dust}
 \end{figure}
 
-Should I quote some statistics about the dust corrections? mostly small? maybe difference before/after applying prior to distance?
-
-\subsection{XD-generated Prior}
-Using \xd\ and the MMLE method described in the methods section, we generate the prior. This is shown in \figurename~\ref{fig:prior}.
-This is the \gaia\ + \tmass\ data set deconvolved with it's noise, so compared with the raw data in \figurename~\ref{fig:data}, this is a tighter distribution. The left panel shows 1.3M samples from the prior distribution, and the right panel shows the underlying gaussian mixture model these samples are drawn from. The main sequence and red giant branch are much tighter, as well as the red clump. We'll come back to more features in the data below, especially those seen in the posterior distribution.
+\subsection{The empirical prior}
+Using \xd\ and the MMLE method described in the methods section, we generate the
+prior, shown in \figurename~\ref{fig:prior}.
+The left panel shows 1.3 million samples from the prior distribution, and the
+right panel shows $1\sigma$ contours for each component in the underlying
+Gaussian mixture model.
+Compared to the raw data in \figurename~\ref{fig:data}, the deconvolved
+color--magnitude diagram for the \gaia\ + \tmass\ stars is tighter, as expected.
+We'll come back to more features in the data below, especially those seen in the posterior distribution.
 \begin{figure}
 \centering
   \includegraphics[width=\textwidth]{prior_ngauss128.png}
@@ -555,7 +575,7 @@ This is the \gaia\ + \tmass\ data set deconvolved with it's noise, so compared w
   contours. The right panel shows the 1-$\sigma$ contours of the
   individual components. The latter are Gaussian in the transformed
   magnitude space to make the XD inference tractable. Thus, they
-  appear non-Gaussian in the physical color--magnitude space.}
+  appear as slightly deformed ellipses in color--magnitude space.}
 \label{fig:prior}
 \end{figure}
 
@@ -621,17 +641,17 @@ paper or any other data outputs straightforwardly.
 
 \subsection{Distances to M67}
 As a test of the accuracy of these photometric parallax inferences, we inferred the parallaxes to stars in the open cluster M67.
-It is an open cluster in the constellation Cancer and is estimated to be 3-5 billion years old and 800-900 pc away.
-Previous work \citep{cbj15} has estimated that bad things happen if you try to infer a distance as the inverse of the observed (noisy) parallax when the signal to noise of the parallax measurement drops below 5.
-With \gaia\ parallaxes having a minimum uncertainty of about 0.3 mas, the SN reaches 5 for the most certain parallax measurements at about 700 pc, right where this cluster lies.
-So it is a great test case for comparing parallax inferences with or without a prior.
-We made a window of 1 square degree on the sky with the cluster M67 lying in the middle.
-The cluster is visibly obvious as a clustering of stars in a visualization of the \gaia\ data on the 2D sky.
+M67 is at a Heliocentric distance of $800$--$900~{\rm pc}$ with an estimated age of 3--$5~{\rm Gyr}$.
+Previous work \citep{cbj15} has noted that bad things happen if you try to infer a distance as the inverse of the observed (noisy) parallax when the parallax signal-to-noise (SN) is below 5, $\varpi / \sigma_\varpi < 5$.
+With \gaia\ parallaxes having a minimum uncertainty of about $0.3~{\rm mas}$, the SN reaches 5 for the most certain parallax measurements at about $700~{\rm pc}$, just before the distance to this cluster.
+M67 is therefore a great test case for comparing parallax inferences with or without a prior.
+
+We select sources from our catalog within a $1~{\rm deg}^2$ square window centered on the position of M67; the cluster is visible as an over-density of stars in the sky positions alone.
 With our converged dust values, and its associated prior, we calculate the posterior over $\varpi_{\true}$ for each star within this window on the sky around M67.
 \figurename~\ref{fig:m67} shows the comparison of the likelihoods and posteriors.
 The vertical lines bracket the previously measured parallaxes of, or distances to, the cluster.
-The likelihoods of the observed parallaxes, shown in the top row, are broad and the cluster is not obvious at all.
-The posterior pdf, shown in the bottom row, are more sharply peaked at the previously determined distance to the cluster, the vertical lines, for far more stars than the likelihoods.
+The likelihoods of the observed parallaxes, shown in the top row, are broad and the cluster is not at all obvious.
+The posterior pdfs, shown in the bottom row, are more sharply peaked at the previously determined distance to the cluster (vertical lines) for far more stars.
 Our prior is not only making parallaxes more precise but also (possibly) increasing the accuracy.
 \begin{figure}
 \centering

--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -53,28 +53,31 @@
 %\affil{Department of Astronomy and Astrophysics, University of Toronto, 50 St. George Street, Toronto, ON M5S 3H4, Canada}
 
 \begin{abstract}\noindent % trust me
-Conversion of a noisy parallax measurement into a posterior
-belief over distances requires inference with a prior.
-Usually this prior represents some kind of belief about the Milky Way.
-However, there is multi-band photometry for a large fraction of the
-\gaia\ \tgas\ Catalog from imaging surveys;
-this imaging is incredibly informative about stellar distances.
-Here we use color information for $1.2$ million \tgas\ stars
-from \tmass\ to build a noise-deconvolved empirical prior distribution for stars in color--magnitude space.
-This data-driven model contains no knowledge of the physics of stellar interiors or photospheres, nor of the Milky Way, but rather derives its precision from its generative model of noisy parallax measurements and an assumption of stationarity.
-We use the Extreme Deconvolution (\xd) algorithm, which is an Empirical Bayes approximation to a full hierarchical model of the true parallax and photometry of every star.
-The algorithm is run not in absolute-magnitude space but in a
-transformed space where the measurement uncertainty is close to Gaussian.
-The \xd-optimized prior is used to perform parallax inferences for every star, yielding a precise photometric parallax estimate and uncertainty (and full posterior) for every star.
-Our posterior photometric parallax estimates are more precise than the
-\tgas\ catalog entries by a median factor of 1.2, and 14 percent
-are more precise by a factor $>2$. They are also more precise than
-previous examples of Bayesian distance estimates using a spatial prior.
-We independently validate our parallax inferences distances by looking
-at members of Milky Way star cluster M67, which is not visible as a
-cluster in the \tgas\ parallax estimates, but appears clearly as a
-cluster in our posterior parallax estimates.
-All our results, including a posterior parallax and distance sampling for 1.4 million \tgas\ stars, are available in companion electronic tables.
+Converting a noisy parallax measurement into a posterior
+belief over distance requires inference with a prior.
+Usually this prior represents beliefs about the stellar density distribution of
+the Milky Way.
+However, multi-band photometry exists for a large fraction of the
+\gaia\ \tgas\ Catalog and is incredibly informative about stellar distances.
+Here we use \tmass\ colors for $1.2$ million \tgas\ stars to build a
+noise-deconvolved empirical prior distribution for stars in color--magnitude
+space.
+This data-driven model contains no knowledge of stellar astrophysics or the
+Milky Way, but rather derives its precision from its generative model of noisy
+parallax measurements and an assumption of stationarity.
+We use the Extreme Deconvolution (\xd) algorithm---an approximation to a full
+hierarchical model of the true parallax and photometry of every star---to
+construct this prior.
+The \xd-optimized prior is used to infer a precise photometric parallax estimate
+and uncertainty (and full posterior) for every star.
+Our parallax estimates are more precise than the \tgas\ catalog entries by a
+median factor of 1.2 (14\% are more precise by a factor $>2$) and are more
+precise than previous Bayesian distance estimates that use spatial priors.
+We validate our parallax inferences using members of the Milky Way
+star cluster M67, which is not visible as a cluster in the \tgas\ parallax
+estimates, but appears as a cluster in our posterior parallax estimates.
+Our results, including a posterior parallax and distance sampling for 1.4
+million \tgas\ stars, are available in companion electronic tables.
 \end{abstract}
 
 \keywords{
@@ -87,8 +90,6 @@ All our results, including a posterior parallax and distance sampling for 1.4 mi
   parallaxes
   ---
   stars: distances
-  ---
-  stars: statistics
 }
 
 \section{Introduction}

--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -329,7 +329,7 @@ We can get better estimates of the true parallax for each star by inferring the 
 
 \section{Assumptions and methods}\label{sec:method}
 
-To infer the true parallax to a star using the noise-deconvolved \cmd\ as
+To infer the true parallax for a star using the noise-deconvolved \cmd\ as
 a prior, we make the following assumptions. The method we present is correct
 and justifiable under these assumptions, each of which is questionable
 in its own right. We return to criticize these assumptions---and the
@@ -356,7 +356,7 @@ method that flows from them---in the discussion section below.
   approximation to full Bayesian inference. This assumption will be
   least true in the least-populated parts of the \cmd. In the extreme
   case, if a portion of the \cmd\ has only one (statistically distinct)
-  exemplar, for example, a white dwarf, inference for these cases will be biased.
+  exemplar---for example, a white dwarf---inference for these cases will be biased.
 \item[noise model] We assume that the \tgas\ parallax uncertainties dominate the
   noise in any estimates of absolute magnitude. We further assume that
   the parallax and color uncertainties are Gaussian in form with


### PR DESCRIPTION
I made a lot of minor changes to the text (mostly to correct typos, grammar, wording). In some cases, I rearranged sentences to clarify meaning or reduce redundancies. Below are comments that  either (1) are not fixable by me (e.g., figures), (2) require stylistic decisions that I punt to @andersdot (e.g., math typsetting), or (3) missing text that I didn't have time to write. Overall, I think it's a great paper! That said, I don't think it's quite ready for submission -- see comments below.

* Title is a little vague - "Improving Gaia parallaxes" how? What about: "Improving Gaia parallax precision with a data-driven model of the color-magnitude diagram"
* I took it upon myself to squeeze the abstract a bit so it all fits on the first page. I made some possibly controversial changes, but generally just removed fluff words or things I didn't think needed to be mentioned until the introduction. So, have a close read-through of the new abstract - I put all changes into one commit, so we can always roll back those changes without ditching my other proposed changes.
* In the "why does this work section," you say "...the blue points represent the posterior beliefs of the true values..." They are *points* though, so they must be something computed from the posterior samples or the analytic posterior. Are the maximum a posteriori (MAP) values?
* Figure labels with variables should be $x$ and $y$ to be consistent with typesetting in the paper.
* Figures should be PDF's not PNG's!! But don't forget to use `rasterized=True`
* Double check this, but I think the 2MASS K-band filter is technically called (and referred to) as $K_s$
* I tend to use \boldsymbol{} for vectors and capital \mathbf{} for matrices, but your call!
* (Section 3.2) OMG \mathrm{amp} instead of $A$???
* Eq. 15 - aren't \mu_k and V_k both vectors? Should they therefore be bold?
* I think the \alpha on the RHS of Eq. 17 should be \hat{\alpha} (see Eq. 16), but double check.
* When you refer to Pan-STARRS, I think you want to refer to PS1 - the survey that exists right now. I think "Pan-STARRS" refers to the facility at large (which may eventually contain multiple telescopes or whatever). Double check. In other references (e.g., papers by Brani Sesar), my recollection is that it appears as PS1.
* In "Data and results", you say "We use stars crossmatched in \tgas\ and \tmass\..." -- do you use values taken from the Gaia science archive? If so, you should add a footnote linking to the archive so they get a shout-out. 
* The wording in the "Dust" section could use some work - I made some changes, but have another look or re-assign to me!
* In the "Dust" section, I'm not sure what this sentence is trying to say: "This approach minimizes severe distances, and their associated severe dust corrections, which would occur if using the likelihoods alone."
* Also, same section, I don't understand this sentence "For each distance, we sample the median of the probabilistic dust model."
* I would re-make the left panel of Figure 4 using [`astroML.plotting.scatter_contour`](http://www.astroml.org/modules/generated/astroML.plotting.scatter_contour.html) and drop the blue contours. The solid black ink isn't very useful for visualization
* In paragraph 1 of "Shrinkage of parallax uncertainties", I think you could be a bit more expository -- say some more about what you see in Figure 5.
* Caption of Figure 5 is incomplete?
* Caption of Figure 6 doesn't guide the user to left panel/right panel.
* The flow of Section 4 feels a little jumpy to me. But no immediate thoughts on how to fix that without some serious rearranging...
* In "Distance for M67" -- you say "to stars in the open cluster M67". Are these previously-known members? If so, say so
* Why are there so few stars in M67?
* Figure 9 figure caption is incomplete.
* End of the M67 section, you say "Our prior is not only making parallaxes more precise but also (possibly) increasing the accuracy." -- I think you need to explain why you conclude that from the figure.
* Figure 11 figure caption is incomplete.
* in "What's that feature?" - I think "Malmquist bias" needs a citation
* I thought I was strong, but I feel slightly uncomfortable with the snarky conclusion.
* You're missing a "\software{}" section! What software did you use? Here's an example of one of mine:

```latex
\software{
The code used in this project is available from
\url{https://github.com/adrn/GaiaPairsFollowup} under the MIT open-source
software license.
This research utilized the following open-source \python\ packages:
    \package{Astropy} (\citealt{Astropy-Collaboration:2013}),
    \package{astroquery} (\citealt{Ginsburg:2016}),
    \package{ccdproc} (\citealt{Craig:2015}),
    \package{celerite} (\citealt{Foreman-Mackey:2017}),
    \package{IPython} (\citealt{Perez:2007}),
    \package{matplotlib} (\citealt{Hunter:2007}),
    \package{numpy} (\citealt{Van-der-Walt:2011}),
    \package{scipy} (\url{https://www.scipy.org/}),
    \package{sqlalchemy} (\url{https://www.sqlalchemy.org/})
This work additionally used the Gaia science archive
(\url{https://gea.esac.esa.int/archive/}).
}
```

cc @davidwhogg @andersdot 